### PR TITLE
Surface sampling segfaults when LB is turned on

### DIFF
--- a/Allwmake
+++ b/Allwmake
@@ -25,6 +25,7 @@ else
     echo "${WM_PROJECT}-${foamv} is not supported, this toolkit only works with OpenCFD's releases of OpenFOAM."
     exit 1
 fi
+fi
 
 #------------------------------------------------------------------------------
 

--- a/Allwmake
+++ b/Allwmake
@@ -25,7 +25,6 @@ else
     echo "${WM_PROJECT}-${foamv} is not supported, this toolkit only works with OpenCFD's releases of OpenFOAM."
     exit 1
 fi
-fi
 
 #------------------------------------------------------------------------------
 

--- a/Allwmake
+++ b/Allwmake
@@ -5,6 +5,9 @@ cd "${0%/*}" || exit                                # Run from this directory
 #------------------------------------------------------------------------------
 
 foamv=${WM_PROJECT_VERSION}
+curr_branch=$(git branch --show-current)
+if [[ $curr_branch == "master" || $curr_branch == "v2212" ]]; then
+# Switch branches if necessary
 if [[ $foamv =~ ^v([0-9]{4})$ ]]; then
     ver=${BASH_REMATCH[1]}
     if [ "${ver}" -eq "2106" ]; then
@@ -21,6 +24,7 @@ if [[ $foamv =~ ^v([0-9]{4})$ ]]; then
 else
     echo "${WM_PROJECT}-${foamv} is not supported, this toolkit only works with OpenCFD's releases of OpenFOAM."
     exit 1
+fi
 fi
 
 #------------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -26,10 +26,6 @@ This repository extracts library parts from [blastFoam](https://github.com/synth
 
 To get started, you can visit the one and only [wiki page](https://github.com/STFS-TUDa/blastAMR/wiki).
 
-> [!NOTE]
-> If you're using OpenFOAM v2206 or newer, please switch to the `v2212` branch. The `master` branch is for OpenFOAM v2112
-> and earlier versions for now. See #6.
-
 ## Objectives
 
 - Have a reasonable Load-balanced AMR for 2D/3D OpenFOAM meshes in the **ESI fork**.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ This repository extracts library parts from [blastFoam](https://github.com/synth
 
 To get started, you can visit the one and only [wiki page](https://github.com/STFS-TUDa/blastAMR/wiki).
 
+> [!NOTE]
+> If you're using OpenFOAM v2206 or newer, please switch to the `v2212` branch. The `master` branch is for OpenFOAM v2112
+> and earlier versions for now. See #6.
+
 ## Objectives
 
 - Have a reasonable Load-balanced AMR for 2D/3D OpenFOAM meshes in the **ESI fork**.

--- a/src/errorEstimators/gradientRange/gradientRange.C
+++ b/src/errorEstimators/gradientRange/gradientRange.C
@@ -92,19 +92,21 @@ void gradientEstimator::update(const bool scale)
     }
 
     error_ = 0.0;
-    const auto& vf = mesh_.lookupObject<volScalarField>(gradField_);
+    const auto& T = mesh_.lookupObject<volScalarField>(gradField_);
     const scalar refineThreshold(dict().lookupOrDefault("refineThreshold", 0.5));
     const scalar unrefineThreshold(dict().lookupOrDefault("unrefineThreshold", 0.4));
     Info << "refineThreshold = " << refineThreshold << endl;
     Info << "unrefineThreshold = " << unrefineThreshold << endl;
-    error_ == mag(fvc::grad(vf)) / dimensionedScalar(vf.dimensions()/dimLength,1.0);
+    // @todo: Use cached gradient if possible in gradient-based error indicators
+    // @body: Explore the possibility of using cached field gradients instead of new computations
+    error_ == mag(fvc::grad(T)) / dimensionedScalar(T.dimensions()/dimLength,1.0);
 
-    scalar maxGrad = gMax(error_);
-    scalar minGrad = gMin(error_);
+    scalar maxGradT = gMax(error_);
+    scalar minGradT = gMin(error_);
 
-    lowerRefine_ = minGrad + refineThreshold*(maxGrad-minGrad);
+    lowerRefine_ = minGradT + refineThreshold*(maxGradT-minGradT);
     upperRefine_ =  GREAT;
-    lowerUnrefine_ = minGrad + unrefineThreshold*(maxGrad-minGrad);
+    lowerUnrefine_ = minGradT + unrefineThreshold*(maxGradT-minGradT);
     upperUnrefine_ =  GREAT;
     if (scale) normalize(error_);
 }
@@ -115,4 +117,3 @@ void gradientEstimator::update(const bool scale)
 } // End namespace Foam
 
 // ************************************************************************* //
-

--- a/src/errorEstimators/gradientRange/gradientRange.C
+++ b/src/errorEstimators/gradientRange/gradientRange.C
@@ -92,21 +92,19 @@ void gradientEstimator::update(const bool scale)
     }
 
     error_ = 0.0;
-    const auto& T = mesh_.lookupObject<volScalarField>(gradField_);
+    const auto& vf = mesh_.lookupObject<volScalarField>(gradField_);
     const scalar refineThreshold(dict().lookupOrDefault("refineThreshold", 0.5));
     const scalar unrefineThreshold(dict().lookupOrDefault("unrefineThreshold", 0.4));
     Info << "refineThreshold = " << refineThreshold << endl;
     Info << "unrefineThreshold = " << unrefineThreshold << endl;
-    // @todo: Use cached gradient if possible in gradient-based error indicators
-    // @body: Explore the possibility of using cached field gradients instead of new computations
-    error_ == mag(fvc::grad(T)) / dimensionedScalar(T.dimensions()/dimLength,1.0);
+    error_ == mag(fvc::grad(vf)) / dimensionedScalar(vf.dimensions()/dimLength,1.0);
 
-    scalar maxGradT = gMax(error_);
-    scalar minGradT = gMin(error_);
+    scalar maxGrad = gMax(error_);
+    scalar minGrad = gMin(error_);
 
-    lowerRefine_ = minGradT + refineThreshold*(maxGradT-minGradT);
+    lowerRefine_ = minGrad + refineThreshold*(maxGrad-minGrad);
     upperRefine_ =  GREAT;
-    lowerUnrefine_ = minGradT + unrefineThreshold*(maxGradT-minGradT);
+    lowerUnrefine_ = minGrad + unrefineThreshold*(maxGrad-minGrad);
     upperUnrefine_ =  GREAT;
     if (scale) normalize(error_);
 }

--- a/tutorials/damBreak2D/Allrun
+++ b/tutorials/damBreak2D/Allrun
@@ -3,6 +3,7 @@ cd "${0%/*}" || exit                                # Run from this directory
 . ${WM_PROJECT_DIR:?}/bin/tools/RunFunctions        # Tutorial run functions
 #------------------------------------------------------------------------------
 
+set -e
 restore0Dir
 runApplication blockMesh
 
@@ -21,6 +22,6 @@ for i in $(seq 1 $maxRef); do
 done
 cp -rT 0/polyMesh constant/polyMesh
 runApplication decomposePar -constant
-#mpirun -np 8 --output-filename log interFoam -parallel
+mpirun -np 4 --output-filename log interFoam -parallel
 
 #------------------------------------------------------------------------------

--- a/tutorials/damBreak2D/system/controlDict
+++ b/tutorials/damBreak2D/system/controlDict
@@ -60,6 +60,9 @@ maxAlphaCo      1;
 
 maxDeltaT       1;
 
-//#sinclude   "sampling"
+functions
+{
+    #include "sampling"
+}
 
 // ************************************************************************* //

--- a/tutorials/damBreak2D/system/sampling
+++ b/tutorials/damBreak2D/system/sampling
@@ -1,7 +1,7 @@
 /*--------------------------------*- C++ -*----------------------------------*\
 | =========                 |                                                 |
 | \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox           |
-|  \\    /   O peration     | Version:  v2012                                 |
+|  \\    /   O peration     | Version:  v2112                                 |
 |   \\  /    A nd           | Website:  www.openfoam.com                      |
 |    \\/     M anipulation  |                                                 |
 \*---------------------------------------------------------------------------*/
@@ -14,41 +14,69 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-functions
+__surfaceFieldValue
 {
-    sampleSets
+    type            surfaceFieldValue;
+    libs            (fieldFunctionObjects);
+    log             on;
+    enabled         true;
+    writeControl    timeStep;
+    writeInterval   1;
+    writeFields     false;
+    surfaceFormat   vtk;
+}
+
+
+// * * * * * * * * * * * * * * * * Sampling  * * * * * * * * * * * * * * * * //
+
+// Sample volume fields to surfaces and hold on registry.
+sampled
+{
+    type    surfaces;
+    libs    (sampling);
+    log     true;
+
+    executeControl  timeStep;
+    executeInterval 1;
+    writeControl    none;
+    sampleOnExecute true;
+    surfaceFormat   none;
+    fields      ( p U );
+    surfaces
     {
-        type    sets;
-        libs    (sampling);
-
-        writeControl  timeStep;
-        writeInterval 1;
-
-        setFormat           vtk;
-        interpolationScheme cellPointFace;
-        fields ( alpha.water );
-
-        sets
-        (
-            gauge_1
-            {
-                type    face;
-                axis    y;
-                start   (0.02 0.20 0.005);
-                end     (0.02 0.25 0.005);
-                nPoints 100;
-            }
-
-            gauge_2
-            {
-                type    face;
-                axis    y;
-                start   (0.2 0.03 0.005);
-                end     (0.2 0.55 0.005);
-                nPoints 100;
-            }
-        );
+        walls
+        {
+            type patch;
+            patches ( ".*Wall" );
+            // triangulate     false;
+        }
     }
 }
+
+
+// * * * * * * * * * * * * * * * Calculations  * * * * * * * * * * * * * * * //
+
+nonWeightedAreaAverage
+{
+    ${__surfaceFieldValue}
+    enabled         true;
+
+    regionType      sampledSurface;
+    name            sampledTriSurf;
+    sampledSurfaceDict
+    {
+        type patch;
+        patches ( ".*Wall" );
+        interpolate true;
+    }
+
+    operation       areaAverage;
+    fields          ( p U );
+}
+
+// * * * * * * * * * * * * * * * * * Cleanup * * * * * * * * * * * * * * * * //
+
+#remove "__.*"
+
 
 // ************************************************************************* //


### PR DESCRIPTION
This is in reference to #10 

So far unable to **reliably** reproduce on the damrBreak2D case. so this PR tracks work on this issue.

From the logs provided with #10 it seems the load balancer
segfaults right after the logic that computes the new imbalance (which would be the logic that "redistributes" the mesh).

Tested on the following combinations:
- Decomposition methods: ✅ simple ✅  hierarchical ❌ metis ❌ scotch

ATM; it seems sampling classes don't like excessive boundary changes; probably caching some internal lists, which get outdated with LB ops.

All the errors I got are from: `Foam::sampledPatch::sampleOnFaces` with some reference to interpolation functions, so it's worth testing out different surface sampling ways...