### PR TITLE
Introducing region support

### DIFF
--- a/applications/utilities/updateMesh/createFields.H
+++ b/applications/utilities/updateMesh/createFields.H
@@ -1,36 +1,38 @@
-     // read all registered field objects
-    IOobjectList objects(mesh, runTime.timeName());
+// read all registered field objects
+IOobjectList objects(mesh, runTime.timeName());
 
-    // Read volScalarFields
-    PtrList<volScalarField> vsFlds;
-    ReadFields(mesh, objects, vsFlds);
+// Read volScalarFields
+PtrList<volScalarField> vsFlds;
+ReadFields(mesh, objects, vsFlds);
 
-    // Read volVectorFields
-    PtrList<volVectorField> vvFlds;
-    ReadFields(mesh, objects, vvFlds);
+// Read volVectorFields
+PtrList<volVectorField> vvFlds;
+ReadFields(mesh, objects, vvFlds);
 
-    // Read surfaceScalarFields (phi)
-    PtrList<surfaceScalarField> ssFlds;
-    ReadFields(mesh, objects, ssFlds);
+// Read surfaceScalarFields (phi)
+PtrList<surfaceScalarField> ssFlds;
+ReadFields(mesh, objects, ssFlds);
 
-    // Read surfaceVectorFields (Uf)
-    PtrList<surfaceVectorField> svFlds;
-    ReadFields(mesh, objects, svFlds);
+// Read surfaceVectorFields (Uf)
+PtrList<surfaceVectorField> svFlds;
+ReadFields(mesh, objects, svFlds);
 
-    
-    IOdictionary refineDict
+
+word dictInstance = (regionName == polyMesh::defaultRegion ? runTime.constant() : word(runTime.constant()/regionName));
+IOdictionary refineDict
+(
+    IOobject
     (
-        IOobject
-        (
-            "dynamicMeshDict",
-            runTime.constant(),
-            runTime,
-            IOobject::MUST_READ,
-            IOobject::NO_WRITE
-        )
-    );
+        "dynamicMeshDict",
+        dictInstance,
+        runTime,
+        IOobject::MUST_READ,
+        IOobject::NO_WRITE
+    )
+);
+Info << "Got refineDict" << endl;
 
-    scalar refineInterval = readScalar
-    (
-        refineDict.lookup("refineInterval")
-    );
+scalar refineInterval = readScalar
+(
+    refineDict.lookup("refineInterval")
+);

--- a/applications/utilities/updateMesh/updateMesh.C
+++ b/applications/utilities/updateMesh/updateMesh.C
@@ -40,7 +40,8 @@ Description
 int main(int argc, char *argv[])
 {
     argList::validOptions.insert("overwrite", "");
-#   include "addTimeOptions.H"
+    #include "addTimeOptions.H"
+    #include "addRegionOption.H"
     #include "setRootCase.H"
     bool overwrite = args.found("overwrite");
 
@@ -49,7 +50,7 @@ int main(int argc, char *argv[])
     #include "checkTimeOptions.H"
     runTime.setTime(Times[startTime], startTime);
 
-    #include "createDynamicFvMesh.H"
+    #include "createNamedDynamicFvMesh.H"
     #include "createFields.H"
 
     for (int i=1; i <= refineInterval; i++)


### PR DESCRIPTION
It doesn't seem to require lots of work to get AMR support in for multi-region solvers;
There are some prereqs  though:
- Proper `dynamicFvMesh` support on the solver end

The effects of load-balancing would need to be investigated at client-level. The important bit is that the region-region interfaces need to support arbitrarily-changing boundary patches; including zero-sized ones.

This PR adds a region option for `updateMesh` but doesn't promise complete support for multi-region context.