### PR TITLE
fix: hex refinement history to poly-refiner compatibility

### DIFF
--- a/src/dynamicMesh/fvMeshRefiner/fvMeshPolyRefiner/fvMeshPolyRefiner.C
+++ b/src/dynamicMesh/fvMeshRefiner/fvMeshPolyRefiner/fvMeshPolyRefiner.C
@@ -194,6 +194,14 @@ Foam::fvMeshPolyRefiner::fvMeshPolyRefiner
 
     readDict(dict);
 
+    bool hexRefinementHistory =
+        dict.lookupOrDefault<bool>("hexRefinementHistory", false);
+    if (hexRefinementHistory)
+    {
+        Info<< "hexRefinementHistory enabled: will read hex mesh refinement "
+            << "data if present" << endl;
+    }
+
     // Get number of valid geometric dimensions
     const label nGeometricDirs = mesh_.nGeometricD();
 
@@ -210,7 +218,8 @@ Foam::fvMeshPolyRefiner::fvMeshPolyRefiner
                 (
                     mesh,
                     dict_,
-                    read
+                    read,
+                    hexRefinementHistory
                 )
             );
             break;
@@ -226,7 +235,8 @@ Foam::fvMeshPolyRefiner::fvMeshPolyRefiner
                 (
                     mesh,
                     dict_,
-                    read
+                    read,
+                    hexRefinementHistory
                 )
             );
             break;
@@ -349,6 +359,19 @@ bool Foam::fvMeshPolyRefiner::refine
                 }
             }
 
+            // Protect cells with refinement history from further refinement
+            if (protectRefinementHistory_)
+            {
+                const labelList& cellLevels = refiner_->cellLevel();
+                forAll(cellLevels, celli)
+                {
+                    if (cellLevels[celli] >= 1)
+                    {
+                        refineCell.set(celli, false);
+                    }
+                }
+            }
+
             // Select subset of candidates. Take into account max allowable
             // cells, refinement level, protected cells.
             labelList cellsToRefine
@@ -435,6 +458,19 @@ bool Foam::fvMeshPolyRefiner::refine
                 {
                     label own = mesh_.faceOwner()[facei + p.start()];
                     refineCell.set(own, true);
+                }
+            }
+
+            // Protect cells with refinement history from unrefinement
+            if (protectRefinementHistory_)
+            {
+                const labelList& cellLevels = refiner_->cellLevel();
+                forAll(cellLevels, celli)
+                {
+                    if (cellLevels[celli] >= 1)
+                    {
+                        refineCell.set(celli, true);
+                    }
                 }
             }
 

--- a/src/dynamicMesh/fvMeshRefiner/fvMeshPolyRefiner/fvMeshPolyRefiner.C
+++ b/src/dynamicMesh/fvMeshRefiner/fvMeshPolyRefiner/fvMeshPolyRefiner.C
@@ -325,6 +325,53 @@ bool Foam::fvMeshPolyRefiner::refine
 
     if (preUpdate())
     {
+        // Handle refinementHistory cellZone on first timestep
+        if (protectRefinementHistory_)
+        {
+            const cellZoneMesh& cellZones = mesh_.cellZones();
+            label zoneID = cellZones.findZoneID("refinementHistory");
+
+            if (zoneID == -1)
+            {
+                // Zone doesn't exist, create it with cells that have cellLevel > 0
+                const labelList& cellLevels = refiner_->cellLevel();
+                DynamicList<label> zoneCells(mesh_.nCells());
+
+                forAll(cellLevels, celli)
+                {
+                    if (cellLevels[celli] > 0)
+                    {
+                        zoneCells.append(celli);
+                    }
+                }
+
+                if (zoneCells.size() > 0)
+                {
+                    Info<< "protectRefinementHistory: Creating refinementHistory cellZone with "
+                        << returnReduce(zoneCells.size(), sumOp<label>())
+                        << " cells" << endl;
+
+                    cellZoneMesh& czm = const_cast<cellZoneMesh&>(cellZones);
+                    czm.append
+                    (
+                        new cellZone
+                        (
+                            "refinementHistory",
+                            zoneCells,
+                            czm.size(),
+                            czm
+                        )
+                    );
+                }
+            }
+            else
+            {
+                Info<< "protectRefinementHistory: Found existing refinementHistory cellZone with "
+                    << returnReduce(cellZones[zoneID].size(), sumOp<label>())
+                    << " cells" << endl;
+            }
+        }
+
         // Cells marked for refinement or otherwise protected from unrefinement.
         boolList refineCell(mesh_.nCells());
 
@@ -356,19 +403,6 @@ bool Foam::fvMeshPolyRefiner::refine
                 {
                     label own = mesh_.faceOwner()[facei + p.start()];
                     refineCell.set(own, false);
-                }
-            }
-
-            // Protect cells with refinement history from further refinement
-            if (protectRefinementHistory_)
-            {
-                const labelList& cellLevels = refiner_->cellLevel();
-                forAll(cellLevels, celli)
-                {
-                    if (cellLevels[celli] >= 1)
-                    {
-                        refineCell.set(celli, false);
-                    }
                 }
             }
 
@@ -461,15 +495,18 @@ bool Foam::fvMeshPolyRefiner::refine
                 }
             }
 
-            // Protect cells with refinement history from unrefinement
+            // Protect cells in refinementHistory zone from unrefinement
             if (protectRefinementHistory_)
             {
-                const labelList& cellLevels = refiner_->cellLevel();
-                forAll(cellLevels, celli)
+                const cellZoneMesh& cellZones = mesh_.cellZones();
+                label zoneID = cellZones.findZoneID("refinementHistory");
+
+                if (zoneID != -1)
                 {
-                    if (cellLevels[celli] >= 1)
+                    const cellZone& zone = cellZones[zoneID];
+                    forAll(zone, i)
                     {
-                        refineCell.set(celli, true);
+                        refineCell.set(zone[i], true);
                     }
                 }
             }

--- a/src/dynamicMesh/fvMeshRefiner/fvMeshPolyRefiner/polyhedralRefinement/polyhedralRefinement.C
+++ b/src/dynamicMesh/fvMeshRefiner/fvMeshPolyRefiner/polyhedralRefinement/polyhedralRefinement.C
@@ -2056,13 +2056,9 @@ void Foam::polyhedralRefinement::setUnrefinement
 // * * * * * * * * * * * * * * * * Constructors  * * * * * * * * * * * * * * //
 
 Foam::polyhedralRefinement::polyhedralRefinement
-(
-    const polyMesh& mesh,
-    const dictionary& dict,
-    const bool read
-)
+(const polyMesh& mesh, const dictionary& dict, const bool read, const bool hexRefinementHistory)
 :
-    refinement(mesh, dict, read)
+    refinement(mesh, dict, read, hexRefinementHistory)
 {}
 
 

--- a/src/dynamicMesh/fvMeshRefiner/fvMeshPolyRefiner/polyhedralRefinement/polyhedralRefinement.H
+++ b/src/dynamicMesh/fvMeshRefiner/fvMeshPolyRefiner/polyhedralRefinement/polyhedralRefinement.H
@@ -202,7 +202,8 @@ public:
         (
             const polyMesh& mesh,
             const dictionary& dict,
-            const bool read = true
+            const bool read = true,
+            const bool hexRefinementHistory = false
         );
 
 

--- a/src/dynamicMesh/fvMeshRefiner/fvMeshPolyRefiner/prismatic2DRefinement/prismatic2DRefinement.C
+++ b/src/dynamicMesh/fvMeshRefiner/fvMeshPolyRefiner/prismatic2DRefinement/prismatic2DRefinement.C
@@ -2710,10 +2710,11 @@ Foam::prismatic2DRefinement::prismatic2DRefinement
 (
     const polyMesh& mesh,
     const dictionary& dict,
-    const bool read
+    const bool read,
+    const bool hexRefinementHistory
 )
 :
-    refinement(mesh, dict, read)
+    refinement(mesh, dict, read, hexRefinementHistory)
 {}
 
 

--- a/src/dynamicMesh/fvMeshRefiner/fvMeshPolyRefiner/prismatic2DRefinement/prismatic2DRefinement.H
+++ b/src/dynamicMesh/fvMeshRefiner/fvMeshPolyRefiner/prismatic2DRefinement/prismatic2DRefinement.H
@@ -212,7 +212,8 @@ public:
         (
             const polyMesh& mesh,
             const dictionary& dict,
-            const bool read = true
+            const bool read = true,
+            const bool hexRefinementHistory = false
         );
 
 

--- a/src/dynamicMesh/fvMeshRefiner/fvMeshPolyRefiner/refinement/refinement.C
+++ b/src/dynamicMesh/fvMeshRefiner/fvMeshPolyRefiner/refinement/refinement.C
@@ -33,6 +33,7 @@ License
 #include "syncTools.H"
 #include "meshTools.H"
 #include "hexRef.H"
+#include "hexRefRefinementHistory.H"
 #include "dynMeshTools.H"
 #include "mapPolyMesh.H"
 #include "mapDistributePolyMesh.H"
@@ -653,7 +654,8 @@ Foam::refinement::refinement
 (
     const polyMesh& mesh,
     const dictionary& dict,
-    const bool read
+    const bool read,
+    const bool hexRefinementHistory
 )
 :
     mesh_(mesh),
@@ -705,10 +707,95 @@ Foam::refinement::refinement
 {
     if (!parentCells_.headerOk())
     {
-        globalIndex gI(mesh_.nCells());
-        forAll(parentCells_, celli)
+        if (hexRefinementHistory)
         {
-            parentCells_[celli] = gI.toGlobal(parentCells_[celli]);
+            IOobject historyIO
+            (
+                "refinementHistory",
+                mesh_.facesInstance(),
+                polyMesh::meshSubDir,
+                mesh_,
+                IOobject::READ_IF_PRESENT,
+                IOobject::NO_WRITE
+            );
+
+            if (historyIO.typeHeaderOk<hexRefRefinementHistory>(true))
+            {
+                Info<< "Reading hex refinementHistory and converting to parentCells"
+                    << endl;
+
+                // Read the hex refinement history
+                hexRefRefinementHistory history(historyIO);
+
+                // Convert to parentCells format
+                // Strategy: Find the root splitCell for each cell, and use that
+                // as a cluster ID. All cells from the same root get the same ID.
+
+                const labelList& visibleCells = history.visibleCells();
+                const DynamicList<hexRefRefinementHistory::splitCell8>& splitCells =
+                    history.splitCells();
+
+                // First pass: map each splitCell index to its root
+                labelList splitCellRoot(splitCells.size(), -1);
+                forAll(splitCells, sci)
+                {
+                    label rootIdx = sci;
+                    label currentIdx = sci;
+
+                    // Traverse up to find root
+                    while (currentIdx >= 0 && splitCells[currentIdx].parent_ >= 0)
+                    {
+                        currentIdx = splitCells[currentIdx].parent_;
+                        rootIdx = currentIdx;
+                    }
+                    splitCellRoot[sci] = rootIdx;
+                }
+
+                // Second pass: assign cluster IDs to cells
+                // Use the root splitCell index directly as cluster ID
+                // These IDs must be globally consistent (not processor-dependent)
+                globalIndex gI(mesh_.nCells());
+
+                forAll(parentCells_, celli)
+                {
+                    label splitIdx = visibleCells[celli];
+
+                    if (splitIdx >= 0)
+                    {
+                        // Cell has refinement history - use root splitCell as cluster ID
+                        // Use negative values to distinguish from regular cell IDs
+                        // and ensure global consistency
+                        label rootIdx = splitCellRoot[splitIdx];
+                        parentCells_[celli] = -(rootIdx + 1);
+                    }
+                    else
+                    {
+                        // Unrefined cell - it is its own parent (use global cell ID)
+                        parentCells_[celli] = gI.toGlobal(celli);
+                    }
+                }
+
+                Info<< "Converted hex refinementHistory to parentCells format" << nl
+                    << "  Found " << splitCells.size() << " splitCells" << nl
+                    << "  Mapped to " << mesh_.nCells() << " current cells" << endl;
+            }
+            else
+            {
+                // No history found, use identity mapping
+                globalIndex gI(mesh_.nCells());
+                forAll(parentCells_, celli)
+                {
+                    parentCells_[celli] = gI.toGlobal(parentCells_[celli]);
+                }
+            }
+        }
+        else
+        {
+            globalIndex gI(mesh_.nCells());
+            forAll(parentCells_, celli)
+            {
+                parentCells_[celli] = gI.toGlobal(parentCells_[celli]);
+            }
         }
     }
     DebugInfo<< "Created pointLevel and cellLevel" << endl;

--- a/src/dynamicMesh/fvMeshRefiner/fvMeshPolyRefiner/refinement/refinement.H
+++ b/src/dynamicMesh/fvMeshRefiner/fvMeshPolyRefiner/refinement/refinement.H
@@ -224,7 +224,8 @@ public:
         (
             const polyMesh& mesh,
             const dictionary& dict,
-            const bool read = true
+            const bool read = true,
+            const bool hexRefinementHistory = false
         );
 
 

--- a/src/dynamicMesh/fvMeshRefiner/fvMeshRefiner.C
+++ b/src/dynamicMesh/fvMeshRefiner/fvMeshRefiner.C
@@ -433,6 +433,7 @@ Foam::fvMeshRefiner::fvMeshRefiner(fvMesh& mesh)
     nUnrefinementBufferLayers_(0),
 
     protectedPatches_(),
+    protectRefinementHistory_(false),
 
     dumpLevel_(false),
 
@@ -504,6 +505,7 @@ Foam::fvMeshRefiner::fvMeshRefiner
     nUnrefinementBufferLayers_(0),
 
     protectedPatches_(),
+    protectRefinementHistory_(false),
 
     dumpLevel_(false),
 
@@ -561,6 +563,8 @@ void Foam::fvMeshRefiner::readDict(const dictionary& dict)
 
     dumpLevel_ = dict_.lookupOrDefault<bool>("dumpLevel", false);
     protectedPatches_ = dict_.lookupOrDefault("protectedPatches", wordList());
+    protectRefinementHistory_ =
+        dict_.lookupOrDefault<bool>("protectRefinementHistory", false);
 
     refine_ = dict_.lookupOrDefault("refine", true);
     unrefine_ = dict_.lookupOrDefault("unrefine", true);

--- a/src/dynamicMesh/fvMeshRefiner/fvMeshRefiner.H
+++ b/src/dynamicMesh/fvMeshRefiner/fvMeshRefiner.H
@@ -144,6 +144,8 @@ protected:
         //- Protected patches
         wordList protectedPatches_;
 
+        //- Protect cells with refinement history from refinement/unrefinement
+        bool protectRefinementHistory_;
 
         //- Dump cellLevel for postprocessing
         Switch dumpLevel_;

--- a/tutorials/damBreak3D/Allrun
+++ b/tutorials/damBreak3D/Allrun
@@ -33,6 +33,6 @@ runApplication decomposePar -cellDist
 #cp -rT 0/polyMesh constant/polyMesh
 #cp 0/polyMesh/cellLevel 0/cellLevel
 #cp 0/polyMesh/pointLevel 0/pointLevel
-#runParallel interFoam
+runParallel interFoam
 
 #------------------------------------------------------------------------------

--- a/tutorials/damBreak3D/constant/dynamicMeshDict
+++ b/tutorials/damBreak3D/constant/dynamicMeshDict
@@ -1,7 +1,7 @@
 /*--------------------------------*- C++ -*----------------------------------*\
 | =========                 |                                                 |
 | \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox           |
-|  \\    /   O peration     | Version:  2312                                  |
+|  \\    /   O peration     | Version:  2506                                  |
 |   \\  /    A nd           | Website:  www.openfoam.com                      |
 |    \\/     M anipulation  |                                                 |
 \*---------------------------------------------------------------------------*/
@@ -16,7 +16,11 @@ FoamFile
 
 dynamicFvMesh   adaptiveFvMesh;
 
-refiner         hexRefiner;
+refiner         polyRefiner;
+
+hexRefinementHistory true;
+
+protectRefinementHistory true;
 
 errorEstimator  coded;
 
@@ -63,9 +67,9 @@ code            #{
 
 balance         yes;
 
-refineInterval  30;
+refineInterval  1;
 
-unrefineInterval 90;
+unrefineInterval 1;
 
 maxRefinement   2;
 


### PR DESCRIPTION
For an initial hex mesh with local refinement:
<img width="1364" height="841" alt="Screenshot from 2025-11-11 10-09-09" src="https://github.com/user-attachments/assets/62811ad3-8eab-4677-93e8-f8ae63da4937" />

The following configuration:
```cpp
refiner polyRefiner;  // better to use hexRefiner; polyRefiner occurs a one-time history remapping cost
hexRefinementHistory true;  // force remapping of hex refinement history into a format polyRefiner can understand
protectRefinementHistory true;  // protect all 1+ cellLevel cells from refinement and unrefinement
```
yields:
<img width="1369" height="838" alt="Screenshot from 2025-11-11 10-08-21" src="https://github.com/user-attachments/assets/e45f90ef-2581-402e-9ffb-814ff7de3958" />

kind of works on #13 but is an extension for #22 

This now created a `refinementHistory` cell zone that we keep mapping. I cannot decide if this is more efficient, or just asking the error estimators to always select the refined cells (possible with the coded one)

I went with this approach since it's more convenient for users; possibly sacrificing performance - but it's opt-in so users who can/want to use coded error estimator should be able to do this more efficiently.

Note that the history cells can be refined but can never be unrefined. This is done this way to prevent degrading the initial geometry as the unrefinement algorithm wouldn't recover the exact initial mesh due to the load-balancer. So the history cells that get refined will stay refined throughout the simulation

https://github.com/user-attachments/assets/e9662e6d-a3e2-42f6-b42a-8d9a10cb3abb

