### PR TITLE
New Load policies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,12 @@ doc/Doxygen/DTAGS
 
 # Ignore XML reports
 *.xml
+
+*mp4
+*avi
+[0-9]*.[0-9]*/
+[0-9]*/
+!0/
+*pvsm
+log.*
+processor*/

--- a/Allwmake
+++ b/Allwmake
@@ -29,6 +29,8 @@ fi
 
 #------------------------------------------------------------------------------
 
+wmake src/loadPolicies
+wmake src/cpuLoad
 wmake src/errorEstimators
 wmake src/dynamicMesh
 wmake src/dynamicFvMesh

--- a/src/cpuLoad/Make/files
+++ b/src/cpuLoad/Make/files
@@ -1,0 +1,3 @@
+cpuLoadPolicy/cpuLoadPolicy.C
+
+LIB = $(FOAM_USER_LIBBIN)/libamrCPULoad

--- a/src/cpuLoad/Make/options
+++ b/src/cpuLoad/Make/options
@@ -1,0 +1,15 @@
+include $(GENERAL_RULES)/mpi-rules
+
+EXE_INC = $(DEBUG_FLAGS) \
+    $(PFLAGS) $(PINC) \
+    -I$(LIB_SRC)/meshTools/lnInclude \
+    -I$(LIB_SRC)/finiteVolume/lnInclude \
+    -I../loadPolicies/lnInclude
+
+LIB_LIBS = \
+    $(PLIBS) \
+    -lmeshTools \
+    -lfiniteVolume \
+    -L$(USER_FOAM_LIBBIN) -lamrLoadPolicies
+
+EXE_CXXFLAGS += -DMPI_PROFILER_UNIT=Foam::TimeUnit::Milli

--- a/src/cpuLoad/cpuLoadPolicy/cpuLoadPolicy.C
+++ b/src/cpuLoad/cpuLoadPolicy/cpuLoadPolicy.C
@@ -1,0 +1,356 @@
+/*---------------------------------------------------------------------------*\
+  =========                 |
+  \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+   \\    /   O peration     |
+    \\  /    A nd           | Copyright (C) 2014 Tyler Voskuilen
+     \\/     M anipulation  |
+-------------------------------------------------------------------------------
+21-05-2020 Synthetik Applied Technologies: |    Modified original
+                            dynamicRefineBalanceBlastFvMesh class
+                            to be more appilcable to compressible flows.
+                            Improved compatibility with snappyHexMesh.
+-------------------------------------------------------------------------------
+License
+    This file is a derivative work of OpenFOAM.
+
+    OpenFOAM is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    OpenFOAM is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+    for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with OpenFOAM.  If not, see <http://www.gnu.org/licenses/>.
+
+\*---------------------------------------------------------------------------*/
+
+#include "cpuLoadPolicy.H"
+#include "addToRunTimeSelectionTable.H"
+#include "mpi.h"
+
+// * * * * * * * * * * * * * * Static Data Members * * * * * * * * * * * * * //
+
+namespace Foam
+{
+    defineTypeNameAndDebug(cpuLoadPolicy, 0);
+    addToRunTimeSelectionTable(loadPolicy, cpuLoadPolicy, dictionary);
+
+    __attribute__((constructor))
+    void onCPULoadLib() {
+        WarningInFunction
+            << "'libamrCPULoad.so' library loaded. Some MPI calls are overrided just by loading this library!"
+            << nl << tab << "This is the case even if you don't use cpuLoad for load-balancing..."
+            << nl << tab << "Of course this is possible only when this library is loaded before real MPI libs."
+            << nl << endl;
+    }
+}
+
+// MPI call overrides
+WRAP_MPI_FUNCTION(
+    Foam::MPITypeLevel::P2PSend,
+    int,
+    Send,
+    (const void* buf, int count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm),
+    buf, count, datatype, dest, tag, comm
+)
+WRAP_MPI_FUNCTION(
+    Foam::MPITypeLevel::P2PSend,
+    int,
+    Isend,
+    (const void* buf, int count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm, MPI_Request* request),
+    buf, count, datatype, dest, tag, comm, request
+)
+WRAP_MPI_FUNCTION(
+    Foam::MPITypeLevel::P2PSend,
+    int,
+    Bsend,
+    (const void *buf, int count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm),
+    buf, count, datatype, dest, tag, comm
+)
+WRAP_MPI_FUNCTION(
+    Foam::MPITypeLevel::P2PSend,
+    int,
+    Ssend,
+    (const void *buf, int count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm),
+    buf, count, datatype, dest, tag, comm
+)
+WRAP_MPI_FUNCTION(
+    Foam::MPITypeLevel::P2PSend,
+    int,
+    Issend,
+    (const void* buf, int count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm, MPI_Request* request),
+    buf, count, datatype, dest, tag, comm, request
+)
+WRAP_MPI_FUNCTION(
+    Foam::MPITypeLevel::P2PRecv,
+    int,
+    Recv,
+    (void* buf, int count, MPI_Datatype datatype, int source, int tag, MPI_Comm comm, MPI_Status* status),
+    buf, count, datatype, source, tag, comm, status
+)
+WRAP_MPI_FUNCTION(
+    Foam::MPITypeLevel::P2PRecv,
+    int,
+    Irecv,
+    (void* buf, int count, MPI_Datatype datatype, int source, int tag, MPI_Comm comm, MPI_Request* request),
+    buf, count, datatype, source, tag, comm, request
+)
+WRAP_MPI_FUNCTION(
+    Foam::MPITypeLevel::Collective,
+    int,
+    Allgather,
+    (const void* sendbuf, int sendcount, MPI_Datatype sendtype,
+     void* recvbuf, int recvcount, MPI_Datatype recvtype,
+     MPI_Comm comm),
+    sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm
+)
+WRAP_MPI_FUNCTION(
+    Foam::MPITypeLevel::Collective,
+    int,
+    Allreduce,
+    (const void* sendbuf, void* recvbuf, int count, MPI_Datatype datatype,
+     MPI_Op op, MPI_Comm comm),
+    sendbuf, recvbuf, count, datatype, op, comm
+)
+WRAP_MPI_FUNCTION(
+    Foam::MPITypeLevel::Collective,
+    int,
+    Bcast,
+    (void *buffer, int count, MPI_Datatype datatype, int root, MPI_Comm comm),
+    buffer, count, datatype, root, comm
+)
+WRAP_MPI_FUNCTION(
+    Foam::MPITypeLevel::Collective,
+    int,
+    Barrier,
+    (MPI_Comm comm),
+    comm
+)
+WRAP_MPI_FUNCTION(
+    Foam::MPITypeLevel::Other,
+    int,
+    Wait,
+    (MPI_Request *request, MPI_Status *status),
+    request, status
+)
+WRAP_MPI_FUNCTION(
+    Foam::MPITypeLevel::Other,
+    int,
+    Waitall,
+    (int count, MPI_Request *array_of_requests, MPI_Status *array_of_statuses),
+    count, array_of_requests, array_of_statuses
+)
+WRAP_MPI_FUNCTION(
+    Foam::MPITypeLevel::Other,
+    int,
+    Waitany,
+    (int count, MPI_Request *array_of_requests, int *index, MPI_Status *status),
+    count, array_of_requests, index, status
+)
+WRAP_MPI_FUNCTION(
+    Foam::MPITypeLevel::Other,
+    int,
+    Waitsome,
+    (int incount, MPI_Request *array_of_requests, int *outcount, int *array_of_indices, MPI_Status *array_of_statuses),
+    incount, array_of_requests, outcount, array_of_indices, array_of_statuses
+)
+WRAP_MPI_FUNCTION(
+    Foam::MPITypeLevel::Other,
+    int,
+    Test,
+    (MPI_Request *request, int *flag, MPI_Status *status),
+    request, flag, status
+)
+WRAP_MPI_FUNCTION(
+    Foam::MPITypeLevel::Other,
+    int,
+    Testall,
+    (int count, MPI_Request *array_of_requests, int *flag, MPI_Status *array_of_statuses),
+    count, array_of_requests, flag, array_of_statuses
+)
+WRAP_MPI_FUNCTION(
+    Foam::MPITypeLevel::Other,
+    int,
+    Testany,
+    (int count, MPI_Request *array_of_requests, int *index, int *flag, MPI_Status *status),
+    count, array_of_requests, index, flag, status
+)
+WRAP_MPI_FUNCTION(
+    Foam::MPITypeLevel::Other,
+    int,
+    Testsome,
+    (int incount, MPI_Request *array_of_requests, int *outcount, int *array_of_indices, MPI_Status *array_of_statuses),
+    incount, array_of_requests, outcount, array_of_indices, array_of_statuses
+)
+WRAP_MPI_FUNCTION(
+    Foam::MPITypeLevel::Other,
+    int,
+    Accumulate,
+    (const void* origin_addr, int origin_count, MPI_Datatype origin_datatype,
+     int target_rank, MPI_Aint target_disp, int target_count, MPI_Datatype target_datatype,
+     MPI_Op op, MPI_Win win),
+    origin_addr, origin_count, origin_datatype, target_rank, target_disp,
+    target_count, target_datatype, op, win
+)
+WRAP_MPI_FUNCTION(
+    Foam::MPITypeLevel::Other,
+    int,
+    Get,
+    (void *origin_addr, int origin_count, MPI_Datatype origin_datatype,
+     int target_rank, MPI_Aint target_disp, int target_count,
+     MPI_Datatype target_datatype, MPI_Win win),
+    origin_addr, origin_count, origin_datatype, target_rank, target_disp,
+    target_count, target_datatype, win
+)
+WRAP_MPI_FUNCTION(
+    Foam::MPITypeLevel::Other,
+    int,
+    Put,
+    (const void *origin_addr, int origin_count, MPI_Datatype origin_datatype,
+     int target_rank, MPI_Aint target_disp, int target_count,
+     MPI_Datatype target_datatype, MPI_Win win),
+    origin_addr, origin_count, origin_datatype, target_rank, target_disp,
+    target_count, target_datatype, win
+)
+WRAP_MPI_FUNCTION(
+    Foam::MPITypeLevel::Other,
+    int,
+    Win_lock,
+    (int lock_type, int rank, int assert, MPI_Win win),
+    lock_type, rank, assert, win
+)
+WRAP_MPI_FUNCTION(
+    Foam::MPITypeLevel::Other,
+    int,
+    Win_unlock,
+    (int rank, MPI_Win win),
+    rank, win
+)
+WRAP_MPI_FUNCTION(
+    Foam::MPITypeLevel::Other,
+    int,
+    Win_flush,
+    (int rank, MPI_Win win),
+    rank, win
+)
+WRAP_MPI_FUNCTION(
+    Foam::MPITypeLevel::Other,
+    int,
+    Win_flush_all,
+    (MPI_Win win),
+    win
+)
+WRAP_MPI_FUNCTION(
+    Foam::MPITypeLevel::Other,
+    int,
+    Win_flush_local,
+    (int rank, MPI_Win win),
+    rank, win
+)
+WRAP_MPI_FUNCTION(
+    Foam::MPITypeLevel::Other,
+    int,
+    Win_flush_local_all,
+    (MPI_Win win),
+    win
+)
+
+
+
+// * * * * * * * * * * * * * * * * Constructors  * * * * * * * * * * * * * * //
+
+Foam::cpuLoadPolicy::cpuLoadPolicy
+(
+    const fvMesh& mesh,
+    const dictionary& dict
+)
+:
+    loadPolicy(mesh, dict),
+    maxCycleLength_(dict.lookupOrDefault("maxLBCycleLength", 5*readLabel(dict.lookup("refineInterval")))),
+    isActive_(true)
+{
+    mpiCommsStats.reset();
+}
+
+
+// * * * * * * * * * * * * * * * * Destructor  * * * * * * * * * * * * * * * //
+
+Foam::cpuLoadPolicy::~cpuLoadPolicy()
+{}
+
+
+// * * * * * * * * * * * * * * * Member Functions  * * * * * * * * * * * * * //
+
+bool Foam::cpuLoadPolicy::canBalance()
+{
+    if (isActive_ && mesh_.time().timeIndex() > 5) {
+        // check that MPI calls where intercepted
+        // it's highly unlikely that after 5 iterations, no measuremants were picked up!
+        if (
+            returnReduce(mpiCommsStats.nP2PSends, sumOp<int>()) == 0 &&
+            returnReduce(mpiCommsStats.nP2PRecvs, sumOp<int>()) == 0 &&
+            returnReduce(mpiCommsStats.nCollectives, sumOp<int>()) == 0 &&
+            returnReduce(mpiCommsStats.nOthers, sumOp<int>()) == 0
+        ) {
+            FatalErrorInFunction
+                << "Seems like MPI call interception is not working. Make sure to preload the intercepting libraries:"
+                << nl << nl << "LD_PRELOAD=\"$FOAM_USER_LIBBIN/libamrLoadPolicies.so $FOAM_USER_LIBBIN/libamrCPULoad.so\" <your-solver-command>"
+                << nl << nl<< "Library loading order is important, libamrCPULoad.so must load before MPI libs."
+                << nl << "So, no point in continuing..."
+                << abort(FatalError);
+        }
+    }
+    // Stat a new measuring cycle when LB is viable, bound by maxCycleLength_ of
+    // time steps
+    bool newCycle = !returnReduce(stillSameCycle(), orOp<bool>());
+    if (mpiCommsStats.nTSInCycle > maxCycleLength_) newCycle = true;
+    auto now = std::chrono::high_resolution_clock::now();
+    auto elapsed = std::chrono::duration_cast<Duration>(now-mpiCommsStats.cycleStart).count();
+    if (elapsed == 0) return false;
+    if (newCycle) myLoad_ = 0;
+    myLoad_ += elapsed
+        - mpiCommsStats.p2pSendTime - mpiCommsStats.p2pRecvTime
+        - mpiCommsStats.collectiveTime - mpiCommsStats.otherTime;
+    scalar idealLoad = returnReduce(myLoad_, sumOp<scalar>()) / scalar(Pstream::nProcs());
+    scalar maxImbalance = returnReduce(mag(myLoad_ - idealLoad) / idealLoad, maxOp<scalar>());
+    Pout<< "Maximum imbalance found = " << 100*maxImbalance << " %" << endl;
+    Pout<< "Current processor load stats:" << nl << mpiCommsStats << endl;
+    if (maxImbalance < allowedImbalance_)
+    {
+        return false;
+    }
+    // start new cylce only if rebalancing...
+    mpiCommsStats.reset();
+    myLoadHistory_.set(mesh_.time().timeIndex(), myLoad_);
+    //Pout << "Last history datapoint: " << myLoadHistory_.toc() << tab << myLoadHistory_[myLoadHistory_.toc().last()] << endl;
+    if (!myLoadHistory_.empty()) {
+        Pout<< "Current processor load computed from Time index = "
+        << myLoadHistory_.toc().last()
+        << " to Time index = " << mesh_.time().timeIndex() << "s"
+        << nl;
+    }
+    return true;
+}
+
+Foam::scalarField Foam::cpuLoadPolicy::cellWeights() {
+    label idealLoad = returnReduce(myLoad_, sumOp<scalar>()) / scalar(Pstream::nProcs());
+    scalar imbalance = mag(myLoad_ - idealLoad) / idealLoad;
+    if (myLoad_ > idealLoad) imbalance = 1.0/imbalance;
+    return scalarField(mesh_.nCells(), myLoad_ != 0 ? imbalance : 1.0);
+}
+
+bool Foam::cpuLoadPolicy::willBeBeneficial
+(
+    const labelList distribution
+) {
+    // WARN: hard to know beforehand which cells will be beneficial
+    // to move; it's a very dynamic property anyway, so no attempt
+    // to make any guesses
+    return true;
+}
+
+// ************************************************************************* //

--- a/src/cpuLoad/cpuLoadPolicy/cpuLoadPolicy.H
+++ b/src/cpuLoad/cpuLoadPolicy/cpuLoadPolicy.H
@@ -1,0 +1,123 @@
+/*---------------------------------------------------------------------------*\
+  =========                 |
+  \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+   \\    /   O peration     |
+    \\  /    A nd           | Copyright (C) 2014 Tyler Voskuilen
+     \\/     M anipulation  |
+-------------------------------------------------------------------------------
+21-05-2020 Synthetik Applied Technologies: |   Modified original
+                            dynamicRefineBalanceBlastFvMesh class
+                            to be more appilcable to compressible flows.
+                            Improved compatibility with snappyHexMesh.
+-------------------------------------------------------------------------------
+License
+    This file is a derivative work of OpenFOAM.
+
+    OpenFOAM is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    OpenFOAM is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+    for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with OpenFOAM.  If not, see <http://www.gnu.org/licenses/>.
+
+
+Class
+    Foam::cpuLoadPolicy
+
+SourceFiles
+    cpuLoadPolicy.C
+
+Description
+    A load tracked based on local CPU time. Imbalance is calculated irt.
+    ideal average (computation-related) CPU execution time per processor.
+
+Note
+    Relies on a static global for MPI profiling 
+
+\*---------------------------------------------------------------------------*/
+
+#ifndef cpuLoadPolicy_H
+#define cpuLoadPolicy_H
+
+#include "loadPolicy.H"
+#include "mpiOverrides.H"
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+namespace Foam
+{
+
+/*---------------------------------------------------------------------------*\
+                     Class cpuLoadPolicy Declaration
+\*---------------------------------------------------------------------------*/
+
+class cpuLoadPolicy
+:   public loadPolicy
+{
+protected:
+    // Maximum number of time steps to resut MPI data
+    label maxCycleLength_;
+    // Is MPI call interception active
+    bool isActive_;
+
+public:
+
+    //- Runtime type information
+    TypeName("cpuLoad");
+
+    // Constructors
+
+        //- Construct from IOobject
+        cpuLoadPolicy
+        (
+            const fvMesh& mesh,
+            const dictionary& dict
+        );
+
+        //- Disallow default bitwise copy construction
+        cpuLoadPolicy(const cpuLoadPolicy&) = delete;
+
+    //- Destructor
+    virtual ~cpuLoadPolicy();
+
+
+    // Member Functions
+
+        //- Update the mesh for both mesh motion and topology change
+        virtual bool canBalance();
+
+        //- Compute and return cell weights for decomposition
+        virtual scalarField cellWeights();
+
+        //- Predict if LB would be viable
+        virtual bool willBeBeneficial
+        (
+            const labelList distribution
+        );
+
+        inline bool stillSameCycle() const {
+            if (myLoadHistory_.empty()) return false;
+            return mesh_.time().timeIndex() == myLoadHistory_.toc().last();
+        }
+    // Member Operators
+
+        //- Disallow default bitwise assignment
+        void operator=(const cpuLoadPolicy&) = delete;
+};
+
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+} // End namespace Foam
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+#endif
+
+// ************************************************************************* //

--- a/src/cpuLoad/cpuLoadPolicy/mpiOverrides.H
+++ b/src/cpuLoad/cpuLoadPolicy/mpiOverrides.H
@@ -1,0 +1,220 @@
+/*---------------------------------------------------------------------------*\
+  =========                 |
+  \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+   \\    /   O peration     |
+    \\  /    A nd           | Copyright (C) 2014 Tyler Voskuilen
+     \\/     M anipulation  |
+-------------------------------------------------------------------------------
+21-05-2020 Synthetik Applied Technologies: |   Modified original
+                            dynamicRefineBalanceBlastFvMesh class
+                            to be more appilcable to compressible flows.
+                            Improved compatibility with snappyHexMesh.
+-------------------------------------------------------------------------------
+License
+    This file is a derivative work of OpenFOAM.
+
+    OpenFOAM is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    OpenFOAM is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+    for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with OpenFOAM.  If not, see <http://www.gnu.org/licenses/>.
+
+\*---------------------------------------------------------------------------*/
+
+#ifndef mpiOverrides_H
+#define mpiOverrides_H
+
+#include <mpi.h>
+#include <array>
+#include <string_view>
+#include <chrono>
+#include <mutex>
+#include "Ostream.H"
+#include "Pstream.H"
+
+// This file attempts to override original MPI calls to profile processor loads
+// for load-balancing related tasks
+//
+// To generate a list of MPI calls that can potentially be overriden in a codebase.
+// These are the MPI function calls appearing in the code base and having PMPI counterparts
+// ```bash
+// tree-sitter query --scope source.cpp <query_path>
+//             $(find <codebase_path> \( -name "*.H" -o -name "*.C" \) ! -path "*/lnInclude/*") |
+//             sed -n 's/.*\(`\(MPI_\w*\)\).*/\2/p' |
+//             sort | uniq |
+//             while read -r mpi_func; do nm -D <path_to_libmpi.so> | grep "P${mpi_func}$"; done
+// ```
+// The query file should look like:
+// ```query
+// (
+//   (call_expression
+//     function: (identifier) @func
+//     arguments: (argument_list))
+//   (#match? @func "^MPI_")
+// )
+// ```
+
+namespace Foam
+{
+
+enum class TimeUnit {
+    Nano,
+    Micro,
+    Milli
+};
+#ifndef MPI_PROFILER_UNIT
+    constexpr TimeUnit profilerUnit = TimeUnit::Micro;
+#else
+    constexpr TimeUnit profilerUnit = static_cast<TimeUnit>(MPI_PROFILER_UNIT);
+#endif
+template<TimeUnit Unit>
+struct DurationSelector;
+template<> struct DurationSelector<TimeUnit::Nano>  { using type = std::chrono::nanoseconds; };
+template<> struct DurationSelector<TimeUnit::Micro> { using type = std::chrono::microseconds; };
+template<> struct DurationSelector<TimeUnit::Milli> { using type = std::chrono::milliseconds; };
+using Duration = typename DurationSelector<profilerUnit>::type;
+constexpr const char* timeUnitSuffix(TimeUnit unit = profilerUnit) {
+    switch (unit) {
+        case TimeUnit::Milli: return "ms";
+        case TimeUnit::Micro: return "us";
+        case TimeUnit::Nano:  return "ns";
+        default:             return "ns";
+    }
+}
+
+struct MPICommsStats {
+    long long p2pSendTime = 0;  // total P2P time inside send ops
+    long long p2pRecvTime = 0;  // total P2P time inside receive ops
+    long long collectiveTime = 0; // total time inside collective comms ops
+    long long otherTime = 0;
+    int nP2PSends = 0; // number of calls to P2P sends
+    int nP2PRecvs = 0; // number of calls to P2P receives
+    int nCollectives = 0; // number of calls to collective routines
+    int nOthers = 0;
+
+    // when latest cycle of LB has started
+    std::chrono::high_resolution_clock::time_point cycleStart = std::chrono::high_resolution_clock::now();
+    int nTSInCycle = 0;
+
+    static constexpr std::array<std::string_view, 28> overridenMPICalls{
+        "MPI_Send",
+        "MPI_Bsend",
+        "MPI_Isend",
+        "MPI_Ssend",
+        "MPI_Issend",
+        "MPI_Recv",
+        "MPI_Irecv",
+        "MPI_Allgather",
+        "MPI_Allreduce",
+        "MPI_Bcast",
+        "MPI_Barrier",
+        "MPI_Wait",
+        "MPI_Waitall",
+        "MPI_Waitany",
+        "MPI_Waitsome",
+        "MPI_Test",
+        "MPI_Testall",
+        "MPI_Testany",
+        "MPI_Testsome",
+        "MPI_Accumulate",
+        "MPI_Get",
+        "MPI_Put",
+        "MPI_Win_lock",
+        "MPI_Win_unlock",
+        "MPI_Win_flush",
+        "MPI_Win_flush_all",
+        "MPI_Win_flush_local",
+        "MPI_Win_flush_local_all",
+    };
+
+    void reset() {
+        p2pSendTime = 0;
+        p2pRecvTime = 0;
+        collectiveTime = 0;
+        nP2PSends = 0;
+        nP2PRecvs = 0;
+        nCollectives = 0;
+        nOthers = 0;
+        nTSInCycle = 0;
+        cycleStart = std::chrono::high_resolution_clock::now();
+    }
+
+    MPICommsStats operator+(const MPICommsStats& other) const {
+        MPICommsStats result;
+        result.p2pSendTime     = this->p2pSendTime + other.p2pSendTime;
+        result.p2pRecvTime     = this->p2pRecvTime + other.p2pRecvTime;
+        result.collectiveTime  = this->collectiveTime + other.collectiveTime;
+        result.otherTime       = this->otherTime + other.otherTime;
+        result.nP2PSends       = this->nP2PSends + other.nP2PSends;
+        result.nP2PRecvs       = this->nP2PRecvs + other.nP2PRecvs;
+        result.nCollectives    = this->nCollectives + other.nCollectives;
+        result.nOthers         = this->nOthers + other.nOthers;
+        return result;
+    }
+
+    Ostream& operator<<(Ostream& os) const {
+        const char* unit = timeUnitSuffix();
+        os << "P2P Send Time: " << label(p2pSendTime) << " " << unit << ", "
+           << "P2P Recv Time: " << label(p2pRecvTime) << " " << unit << ", "
+           << "Collective Time: " << label(collectiveTime) << " " << unit << ", "
+           << "Other Time: " << label(otherTime) << " " << unit << "," << nl
+           << "nP2PSends: " << nP2PSends << ", "
+           << "nP2PRecvs: " << nP2PRecvs << ", "
+           << "nCollectives: " << nCollectives << ", "
+           << "nOthers: " << nOthers;
+        return os;
+    }
+};
+
+inline Ostream& operator<<(Ostream& os, const MPICommsStats& stats) {
+    return stats.operator<<(os);
+}
+
+static MPICommsStats mpiCommsStats;
+std::mutex mpiCommsStatsMutex; // for safer future
+
+enum class MPITypeLevel { P2PSend, P2PRecv, Collective, Other };
+
+template <MPITypeLevel Level, typename Ret, typename... Args>
+Ret mpiCallProfiler
+(
+    Ret (*pmpi_func)(Args...),
+    Args... args
+) {
+    auto start = std::chrono::high_resolution_clock::now();
+    Ret ret = pmpi_func(std::forward<Args>(args)...);
+    auto end = std::chrono::high_resolution_clock::now();
+    long long elapsed = std::chrono::duration_cast<Duration>(end - start).count();
+
+    std::lock_guard<std::mutex> lock(mpiCommsStatsMutex);
+    if constexpr (Level == MPITypeLevel::P2PRecv) {
+        mpiCommsStats.p2pRecvTime += elapsed;
+        mpiCommsStats.nP2PRecvs++;
+    } else if constexpr (Level == MPITypeLevel::Collective) {
+        mpiCommsStats.collectiveTime += elapsed;
+        mpiCommsStats.nCollectives++;
+    } else if constexpr (Level == MPITypeLevel::Other) {
+        mpiCommsStats.otherTime += elapsed;
+        mpiCommsStats.nOthers++;
+    }
+
+    return ret;
+}
+
+}
+
+#define WRAP_MPI_FUNCTION(Level, RetType, FuncName, Sig, ...) \
+extern "C" RetType MPI_##FuncName Sig { \
+    return Foam::mpiCallProfiler<Level>(PMPI_##FuncName, __VA_ARGS__); \
+}
+
+#endif
+
+// ************************************************************************* //

--- a/src/dynamicFvMesh/Make/options
+++ b/src/dynamicFvMesh/Make/options
@@ -3,6 +3,7 @@ EXE_INC = $(DEBUG_FLAGS) \
     -I$(LIB_SRC)/finiteVolume/lnInclude \
     -I$(LIB_SRC)/dynamicMesh/lnInclude \
     -I$(LIB_SRC)/dynamicFvMesh/lnInclude \
+    -I../loadPolicies/lnInclude \
     -I../dynamicMesh/lnInclude \
     -I../errorEstimators/lnInclude
 
@@ -12,5 +13,6 @@ LIB_LIBS = \
     -ldynamicMesh \
     -ldynamicFvMesh \
     -L$(FOAM_USER_LIBBIN) \
+    -lamrLoadPolicies \
     -lamrDynamicMesh \
     -lamrIndicators

--- a/src/dynamicMesh/Make/options
+++ b/src/dynamicMesh/Make/options
@@ -2,10 +2,12 @@ EXE_INC = $(DEBUG_FLAGS) \
     -I$(LIB_SRC)/finiteVolume/lnInclude \
     -I$(LIB_SRC)/meshTools/lnInclude \
     -I$(LIB_SRC)/dynamicMesh/lnInclude \
-    -I$(LIB_SRC)/parallel/decompose/decompositionMethods/lnInclude
+    -I$(LIB_SRC)/parallel/decompose/decompositionMethods/lnInclude \
+    -I../loadPolicies/lnInclude
 
 LIB_LIBS = \
     -lfiniteVolume \
     -ldynamicMesh \
     -ldecompositionMethods \
-    -L$(FOAM_LIBBIN)/dummy -lptscotchDecomp -lscotchDecomp
+    -L$(FOAM_LIBBIN)/dummy -lptscotchDecomp -lscotchDecomp \
+    -L$(FOAM_USER_LIBBIN) -lamrLoadPolicies -lamrDynamicMesh

--- a/src/dynamicMesh/fvMeshBalance/fvMeshBalance.C
+++ b/src/dynamicMesh/fvMeshBalance/fvMeshBalance.C
@@ -91,8 +91,7 @@ Foam::fvMeshBalance::fvMeshBalance(fvMesh& mesh)
     //preservePatchesDict_(nullptr),
     //preserveBafflesDict_(nullptr),
     distributor_(mesh_),
-    balance_(true),
-    allowableImbalance_(0.2)
+    loadPolicy_(loadPolicy::New(mesh_, dictionary{}))
 {
     if (!constraintsDict_)
     {
@@ -162,8 +161,7 @@ Foam::fvMeshBalance::fvMeshBalance
     //preservePatchesDict_(nullptr),
     //preserveBafflesDict_(nullptr),
     distributor_(mesh_),
-    balance_(false),
-    allowableImbalance_(0.2)
+    loadPolicy_(dict.lookupOrDefault<Switch>("balance", false) ? loadPolicy::New(mesh, dict) : nullptr)
 {
     if (!constraintsDict_)
     {
@@ -218,13 +216,13 @@ void Foam::fvMeshBalance::read(const dictionary& balanceDict)
 {
     if (!Pstream::parRun())
     {
-        balance_ = false;
+        loadPolicy_ = nullptr;
         return;
     }
 
-    balance_ = balanceDict.lookupOrDefault("balance", true);
+    loadPolicy_ = balanceDict.lookupOrDefault("balance", true) ? loadPolicy::New(mesh_, balanceDict) : nullptr;
 
-    if (!balance_)
+    if (!loadPolicy_)
     {
         return;
     }
@@ -247,8 +245,6 @@ void Foam::fvMeshBalance::read(const dictionary& balanceDict)
         }
     }
     decompositionDict_ <<= balanceDict;
-
-    balanceDict.readIfPresent("allowableImbalance", allowableImbalance_);
 }
 
 
@@ -453,78 +449,57 @@ Foam::decompositionMethod& Foam::fvMeshBalance::decomposer() const
 
 bool Foam::fvMeshBalance::canBalance() const
 {
-    if (!balance_)
+    Info<< "Is balancing set up? " << loadPolicy_.valid() << endl;
+    if (!loadPolicy_)
     {
         return false;
     }
 
-    //First determine current level of imbalance - do this for all
-    // parallel runs with a changing mesh, even if balancing is disabled
-    label nGlobalCells = returnReduce(mesh_.nCells(), sumOp<label>());
-    scalar idealNCells =
-        scalar(nGlobalCells)/scalar(Pstream::nProcs());
-    scalar localImbalance = mag(scalar(mesh_.nCells()) - idealNCells);
-    scalar maxImbalance = returnReduce(localImbalance, maxOp<scalar>());
-    scalar maxImbalanceRatio = maxImbalance/idealNCells;
+    if(!loadPolicy_->canBalance()) return false;
 
-    Info<<"Maximum imbalance = " << 100*maxImbalanceRatio << " %" << endl;
-
-    if (debug)
-    {
-        Pout<< " localImbalance = "
-            << 100.0*localImbalance/idealNCells << "%, "
-            << "nCells = " << mesh_.nCells()
-            << endl;
-    }
-
-    //If imbalanced, construct weighted coarse graph (level 0) with node
-    // weights equal to their number of subcells. This partitioning works
-    // as long as the number of level 0 cells is several times greater than
-    // the number of processors.
-    if (maxImbalanceRatio < allowableImbalance_)
-    {
-        return false;
-    }
-
+    Info << "Should balance" << endl;
     // Decompose the mesh with uniform weights
     // The refinementHistory constraint is applied internally
     distribution_ = decomposer().decompose
     (
         mesh_,
-        scalarField(mesh_.nCells(), 1.0)
+        loadPolicy_->cellWeights()
+        //scalarField(mesh_.nCells(), 1.0)
     );
 
     // Check if distribution will improve anything
-    labelList procLoadNew(Pstream::nProcs(), 0);
-    forAll(distribution_, celli)
-    {
-        procLoadNew[distribution_[celli]]++;
-    }
-    reduce(procLoadNew, sumOp<labelList>());
-    if (min(procLoadNew) == 0)
-    {
-        DebugInfo
-            << "New distribtion results in a load of 0. Skipping" << endl;
-        return false;
-    }
-    scalar averageLoadNew
-    (
-        scalar(sum(procLoadNew))/scalar(Pstream::nProcs())
-    );
-    scalar maxDevNew(max(mag(procLoadNew - averageLoadNew))/averageLoadNew);
+    return loadPolicy_->willBeBeneficial(distribution_);
 
-    if (maxDevNew > maxImbalanceRatio*0.99)
-    {
-        Info
-            << "    Not balancing because the new distribution does" << nl
-            << "    not improve the load. Skipping" << nl
-            << "    old imbalance: " << maxImbalanceRatio << nl
-            << "    new imbalance: " << maxDevNew << nl
-            << endl;
-        return false;
-    }
+    //labelList procLoadNew(Pstream::nProcs(), 0);
+    //forAll(distribution_, celli)
+    //{
+    //    procLoadNew[distribution_[celli]]++;
+    //}
+    //reduce(procLoadNew, sumOp<labelList>());
+    //if (min(procLoadNew) == 0)
+    //{
+    //    DebugInfo
+    //        << "New distribtion results in a load of 0. Skipping" << endl;
+    //    return false;
+    //}
+    //scalar averageLoadNew
+    //(
+    //    scalar(sum(procLoadNew))/scalar(Pstream::nProcs())
+    //);
+    //scalar maxDevNew(max(mag(procLoadNew - averageLoadNew))/averageLoadNew);
 
-    return true;
+    //if (maxDevNew > maxImbalanceRatio*0.99)
+    //{
+    //    Info
+    //        << "    Not balancing because the new distribution does" << nl
+    //        << "    not improve the load. Skipping" << nl
+    //        << "    old imbalance: " << maxImbalanceRatio << nl
+    //        << "    new imbalance: " << maxDevNew << nl
+    //        << endl;
+    //    return false;
+    //}
+
+    //return true;
 }
 
 
@@ -596,7 +571,7 @@ bool Foam::fvMeshBalance::write(const bool write) const
 {
     if
     (
-        balance_ && modified_ && write &&
+        loadPolicy_ && modified_ && write &&
         decompositionDict_.lookupOrDefault("writeDecomposeDict", false)
     )
     {

--- a/src/dynamicMesh/fvMeshBalance/fvMeshBalance.H
+++ b/src/dynamicMesh/fvMeshBalance/fvMeshBalance.H
@@ -38,6 +38,7 @@ Description
 #define fvMeshBalance_H
 
 #include "fvMeshDistribute.H"
+#include "loadPolicy.H"
 #include "mapDistributePolyMesh.H"
 
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
@@ -89,11 +90,7 @@ protected:
 
         fvMeshDistribute distributor_;
 
-        //- Does the mesh get balanced
-        bool balance_;
-
-        //- Allowable imbalance
-        scalar allowableImbalance_;
+        mutable autoPtr<loadPolicy> loadPolicy_;
 
         //- Distribution
         mutable labelList distribution_;
@@ -135,13 +132,7 @@ public:
         //- Is balancing enabled
         bool balance() const
         {
-            return balance_;
-        }
-
-        //- Access if balancing enabled
-        bool& balance()
-        {
-            return balance_;
+            return loadPolicy_.valid();
         }
 
         //- Does the mesh need to be balanced

--- a/src/dynamicMesh/fvMeshRefiner/fvMeshPolyRefiner/fvMeshPolyRefiner.C
+++ b/src/dynamicMesh/fvMeshRefiner/fvMeshPolyRefiner/fvMeshPolyRefiner.C
@@ -546,6 +546,7 @@ bool Foam::fvMeshPolyRefiner::refine
         {
             hasChanged = true;
         }
+        reduce(hasChanged, orOp<bool>());
         mesh_.topoChanging(hasChanged);
 
         if (hasChanged)

--- a/src/dynamicMesh/fvMeshRefiner/fvMeshRefiner.C
+++ b/src/dynamicMesh/fvMeshRefiner/fvMeshRefiner.C
@@ -626,6 +626,7 @@ bool Foam::fvMeshRefiner::balance()
     balancer_.read(balanceDict);
 
     // Part 2 - Load Balancing
+    Info << "---------------- CAN I BALANCE? " << canBalance() << endl;
     if (canBalance(true))
     {
         isBalancing_ = true;

--- a/src/dynamicMesh/fvMeshRefiner/fvMeshRefiner.H
+++ b/src/dynamicMesh/fvMeshRefiner/fvMeshRefiner.H
@@ -369,7 +369,7 @@ public:
         ) = 0;
 
         //- Balance the mesh
-        virtual bool balance();
+        bool balance();
 
         //- Overload update mesh to include other methods
         virtual void updateMesh(const mapPolyMesh& mpm);

--- a/src/errorEstimators/cellSize/cellSize.C
+++ b/src/errorEstimators/cellSize/cellSize.C
@@ -132,6 +132,54 @@ Foam::labelList Foam::errorEstimators::cellSize::maxRefinement() const
     return mesh_.lookupObject<labelIOList>("cellLevel") + 1;
 }
 
+void Foam::errorEstimators::cellSize::computeDx() {
+    if (sizeType_ == VOLUME)
+    {
+        this->error_.internalFieldRef().field() = mesh_.V().field();
+    }
+    else if (sizeType_ == CHARACTERISTIC)
+    {
+        this->error_.internalFieldRef().field() = meshSizeObject::New(mesh_).dx();
+    }
+    else if (sizeType_ == MAG)
+    {
+        const vectorField& dX = meshSizeObject::New(mesh_).dX();
+        const Vector<label> geoD(mesh_.geometricD());
+        this->error_.internalFieldRef() = 0.0;
+        forAll(geoD, cmpti)
+        {
+            if (geoD[cmpti] == 1)
+            {
+                this->error_.internalFieldRef().field() += sqr(dX.component(cmpti));
+            }
+        }
+        this->error_.internalFieldRef() = sqrt(this->error_.internalFieldRef());
+    }
+    else if (sizeType_ == CMPT)
+    {
+        const vectorField& dX = meshSizeObject::New(mesh_).dX();
+        forAll(cmpts_, i)
+        {
+            label cmpti = cmpts_[i];
+            forAll(this->error_.internalFieldRef(), celli)
+            {
+                if (dX[celli][cmpti] > maxDX_[cmpti])
+                {
+                    this->error_.internalFieldRef()[celli] = max(1.0, this->error_.internalFieldRef()[celli]);
+                }
+                else if (dX[celli][cmpti] < minDX_[cmpti])
+                {
+                    this->error_.internalFieldRef()[celli] = max(-1.0, this->error_.internalFieldRef()[celli]);
+                }
+                else
+                {
+                    this->error_.internalFieldRef()[celli] = max(0, this->error_.internalFieldRef()[celli]);
+                }
+            }
+        }
+    }
+}
+
 
 void Foam::errorEstimators::cellSize::update(const bool scale)
 {
@@ -140,68 +188,23 @@ void Foam::errorEstimators::cellSize::update(const bool scale)
         return;
     }
 
-    scalarField& errorCells(error_);
-    if (sizeType_ == VOLUME)
-    {
-        errorCells = mesh_.V();
-    }
-    else if (sizeType_ == CHARACTERISTIC)
-    {
-        errorCells = meshSizeObject::New(mesh_).dx();
-    }
-    else if (sizeType_ == MAG)
-    {
-        const vectorField& dX = meshSizeObject::New(mesh_).dX();
-        const Vector<label> geoD(mesh_.geometricD());
-        errorCells = 0.0;
-        forAll(geoD, cmpti)
-        {
-            if (geoD[cmpti] == 1)
-            {
-                errorCells += sqr(dX.component(cmpti));
-            }
-        }
-        errorCells = sqrt(errorCells);
-    }
-    else if (sizeType_ == CMPT)
-    {
-        const vectorField& dX = meshSizeObject::New(mesh_).dX();
-        forAll(cmpts_, i)
-        {
-            label cmpti = cmpts_[i];
-            forAll(errorCells, celli)
-            {
-                if (dX[celli][cmpti] > maxDX_[cmpti])
-                {
-                    errorCells[celli] = max(1.0, errorCells[celli]);
-                }
-                else if (dX[celli][cmpti] < minDX_[cmpti])
-                {
-                    errorCells[celli] = max(-1.0, errorCells[celli]);
-                }
-                else
-                {
-                    errorCells[celli] = max(0, errorCells[celli]);
-                }
-            }
-        }
-    }
+    computeDx();
 
     if (sizeType_ != CMPT)
     {
-        forAll(errorCells, celli)
+        forAll(this->error_.internalFieldRef(), celli)
         {
-            if (errorCells[celli] < lowerUnrefine_)
+            if (this->error_.internalFieldRef()[celli] < lowerUnrefine_)
             {
-                errorCells[celli] = -1.0;
+                this->error_.internalFieldRef()[celli] = -1.0;
             }
-            else if (errorCells[celli] > lowerRefine_)
+            else if (this->error_.internalFieldRef()[celli] > lowerRefine_)
             {
-                errorCells[celli] = 1.0;
+                this->error_.internalFieldRef()[celli] = 1.0;
             }
             else
             {
-                errorCells[celli] = 0.0;
+                this->error_.internalFieldRef()[celli] = 0.0;
             }
         }
     }
@@ -216,7 +219,6 @@ void Foam::errorEstimators::cellSize::read(const dictionary& dict)
         cmpts_ = readCmpts(dict.lookup("cmpts"));
         minDX_ = vector(dict.lookup("minDX"));
         maxDX_ = vector(dict.lookup("maxDX"));
-        Info<<cmpts_<<endl;
     }
     else if (sizeType_ == VOLUME)
     {

--- a/src/errorEstimators/cellSize/cellSize.H
+++ b/src/errorEstimators/cellSize/cellSize.H
@@ -93,6 +93,7 @@ public:
     // Member Functions
 
         //- Update error
+        void computeDx();
         virtual void update(const bool scale = true);
 
         //- Return non constant reference to error field
@@ -100,6 +101,20 @@ public:
 
         //- Read parameters
         virtual void read(const dictionary& dict);
+
+        word sizeType() const {
+            return sizeTypeNames[sizeType_];
+        }
+        scalar maxDx() const {
+            return gMax(this->error_.internalField());
+        }
+        scalar minDx() const {
+            return gMin(this->error_.internalField());
+        }
+        labelList cmpts() const {
+            return cmpts_;
+        }
+
 };
 
 

--- a/src/loadPolicies/Make/files
+++ b/src/loadPolicies/Make/files
@@ -1,0 +1,4 @@
+loadPolicy/loadPolicy.C
+cellCountPolicy/cellCountPolicy.C
+
+LIB = $(FOAM_USER_LIBBIN)/libamrLoadPolicies

--- a/src/loadPolicies/Make/options
+++ b/src/loadPolicies/Make/options
@@ -1,0 +1,7 @@
+EXE_INC = $(DEBUG_FLAGS) \
+    -I$(LIB_SRC)/meshTools/lnInclude \
+    -I$(LIB_SRC)/finiteVolume/lnInclude
+
+LIB_LIBS = \
+    -lmeshTools \
+    -lfiniteVolume

--- a/src/loadPolicies/cellCountPolicy/cellCountPolicy.C
+++ b/src/loadPolicies/cellCountPolicy/cellCountPolicy.C
@@ -1,0 +1,123 @@
+/*---------------------------------------------------------------------------*\
+  =========                 |
+  \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+   \\    /   O peration     |
+    \\  /    A nd           | Copyright (C) 2014 Tyler Voskuilen
+     \\/     M anipulation  |
+-------------------------------------------------------------------------------
+21-05-2020 Synthetik Applied Technologies: |    Modified original
+                            dynamicRefineBalanceBlastFvMesh class
+                            to be more appilcable to compressible flows.
+                            Improved compatibility with snappyHexMesh.
+-------------------------------------------------------------------------------
+License
+    This file is a derivative work of OpenFOAM.
+
+    OpenFOAM is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    OpenFOAM is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+    for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with OpenFOAM.  If not, see <http://www.gnu.org/licenses/>.
+
+\*---------------------------------------------------------------------------*/
+
+#include "cellCountPolicy.H"
+#include "addToRunTimeSelectionTable.H"
+
+// * * * * * * * * * * * * * * Static Data Members * * * * * * * * * * * * * //
+
+namespace Foam
+{
+    defineTypeNameAndDebug(cellCountPolicy, 0);
+    addToRunTimeSelectionTable(loadPolicy, cellCountPolicy, dictionary);
+}
+
+// * * * * * * * * * * * * * * * * Constructors  * * * * * * * * * * * * * * //
+
+Foam::cellCountPolicy::cellCountPolicy
+(
+    const fvMesh& mesh,
+    const dictionary& dict
+)
+:
+    loadPolicy(mesh, dict)
+{
+}
+
+
+// * * * * * * * * * * * * * * * * Destructor  * * * * * * * * * * * * * * * //
+
+Foam::cellCountPolicy::~cellCountPolicy()
+{}
+
+
+// * * * * * * * * * * * * * * * Member Functions  * * * * * * * * * * * * * //
+
+bool Foam::cellCountPolicy::canBalance()
+{
+    Info<< "--- Running cellCountPolicy::canBalance()" << endl;
+    myLoad_ = mesh_.nCells();
+    myLoadHistory_.set(mesh_.time().timeIndex(), myLoad_);
+    label nGlobalCells = returnReduce(mesh_.nCells(), sumOp<label>());
+    scalar idealNCells =
+        scalar(nGlobalCells)/scalar(Pstream::nProcs());
+    scalar maxImbalance = returnReduce(mag(scalar(mesh_.nCells()) - idealNCells) / idealNCells, maxOp<scalar>());
+    Info<< "Maximum imbalance found = " << 100*maxImbalance << " %" << endl;
+    if (maxImbalance < allowedImbalance_)
+    {
+        return false;
+    }
+    return true;
+}
+
+Foam::scalarField Foam::cellCountPolicy::cellWeights() {
+    return scalarField(mesh_.nCells(), 1.0);
+}
+
+bool Foam::cellCountPolicy::willBeBeneficial
+(
+    const labelList distribution
+) {
+    labelList procLoadNew(Pstream::nProcs(), 0);
+    forAll(distribution, celli)
+    {
+        procLoadNew[distribution[celli]]++;
+    }
+    reduce(procLoadNew, sumOp<labelList>());
+    if (min(procLoadNew) == 0)
+    {
+        DebugInfo
+            << "New distribtion results in a load of 0. Skipping" << endl;
+        return false;
+    }
+    scalar averageLoadNew
+    (
+        scalar(sum(procLoadNew))/scalar(Pstream::nProcs())
+    );
+    scalar maxDevNew(max(mag(procLoadNew - averageLoadNew))/averageLoadNew);
+
+    // TODO: A bit of repetition here, maybe factor out the imbalance logic from canBalance
+    scalar nGlobalCells = returnReduce(myLoad_, sumOp<scalar>());
+    scalar idealNCells = nGlobalCells/Pstream::nProcs();
+    scalar maxImbalance = returnReduce(mag(myLoad_ - idealNCells)/idealNCells, maxOp<scalar>());
+    if (maxDevNew > maxImbalance*0.99)
+    {
+        Info
+            << "    Not balancing because the new distribution does" << nl
+            << "    not improve the load. Skipping" << nl
+            << "    old imbalance: " << maxImbalance << nl
+            << "    new imbalance: " << maxDevNew << nl
+            << endl;
+        return false;
+    }
+    return true;
+}
+
+// ************************************************************************* //

--- a/src/loadPolicies/cellCountPolicy/cellCountPolicy.H
+++ b/src/loadPolicies/cellCountPolicy/cellCountPolicy.H
@@ -1,0 +1,109 @@
+/*---------------------------------------------------------------------------*\
+  =========                 |
+  \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+   \\    /   O peration     |
+    \\  /    A nd           | Copyright (C) 2014 Tyler Voskuilen
+     \\/     M anipulation  |
+-------------------------------------------------------------------------------
+21-05-2020 Synthetik Applied Technologies: |   Modified original
+                            dynamicRefineBalanceBlastFvMesh class
+                            to be more appilcable to compressible flows.
+                            Improved compatibility with snappyHexMesh.
+-------------------------------------------------------------------------------
+License
+    This file is a derivative work of OpenFOAM.
+
+    OpenFOAM is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    OpenFOAM is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+    for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with OpenFOAM.  If not, see <http://www.gnu.org/licenses/>.
+
+
+Class
+    Foam::cellCountPolicy
+
+SourceFiles
+    cellCountPolicy.C
+
+Description
+    A load tracked based on local cell count. Imbalance is calculated irt.
+    ideal average cell count per processor.
+
+\*---------------------------------------------------------------------------*/
+
+#ifndef cellCountPolicy_H
+#define cellCountPolicy_H
+
+#include "loadPolicy.H"
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+namespace Foam
+{
+
+/*---------------------------------------------------------------------------*\
+                     Class cellCountPolicy Declaration
+\*---------------------------------------------------------------------------*/
+
+class cellCountPolicy
+:   public loadPolicy
+{
+public:
+
+    //- Runtime type information
+    TypeName("cellCount");
+
+    // Constructors
+
+        //- Construct from IOobject
+        cellCountPolicy
+        (
+            const fvMesh& mesh,
+            const dictionary& dict
+        );
+
+        //- Disallow default bitwise copy construction
+        cellCountPolicy(const cellCountPolicy&) = delete;
+
+    //- Destructor
+    virtual ~cellCountPolicy();
+
+
+    // Member Functions
+
+        //- Update the mesh for both mesh motion and topology change
+        virtual bool canBalance();
+
+        //- Compute and return cell weights for decomposition
+        virtual scalarField cellWeights();
+
+        //- Predict if LB would be viable
+        virtual bool willBeBeneficial
+        (
+            const labelList distribution
+        );
+
+    // Member Operators
+
+        //- Disallow default bitwise assignment
+        void operator=(const cellCountPolicy&) = delete;
+};
+
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+} // End namespace Foam
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+#endif
+
+// ************************************************************************* //

--- a/src/loadPolicies/loadPolicy/loadPolicy.C
+++ b/src/loadPolicies/loadPolicy/loadPolicy.C
@@ -1,0 +1,93 @@
+/*---------------------------------------------------------------------------*\
+  =========                 |
+  \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+   \\    /   O peration     |
+    \\  /    A nd           | Copyright (C) 2014 Tyler Voskuilen
+     \\/     M anipulation  |
+-------------------------------------------------------------------------------
+21-05-2020 Synthetik Applied Technologies: |    Modified original
+                            dynamicRefineBalanceBlastFvMesh class
+                            to be more appilcable to compressible flows.
+                            Improved compatibility with snappyHexMesh.
+-------------------------------------------------------------------------------
+License
+    This file is a derivative work of OpenFOAM.
+
+    OpenFOAM is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    OpenFOAM is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+    for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with OpenFOAM.  If not, see <http://www.gnu.org/licenses/>.
+
+\*---------------------------------------------------------------------------*/
+
+#include "loadPolicy.H"
+#include "addToRunTimeSelectionTable.H"
+
+// * * * * * * * * * * * * * * Static Data Members * * * * * * * * * * * * * //
+
+namespace Foam
+{
+    defineTypeNameAndDebug(loadPolicy, 0);
+    defineRunTimeSelectionTable(loadPolicy, dictionary);
+}
+
+// * * * * * * * * * * * * * * * * Constructors  * * * * * * * * * * * * * * //
+
+Foam::loadPolicy::loadPolicy
+(
+    const fvMesh& mesh,
+    const dictionary& dict
+)
+:
+    mesh_(mesh),
+    dict_(dict),
+    allowedImbalance_(dict.lookupOrDefault<scalar>("allowableImbalance", 0.2)),
+    myLoad_(-1),
+    myLoadHistory_()
+{
+    Info<< "---- Attempt at creating load Policy..." << endl;
+}
+
+
+// * * * * * * * * * * * * * * * * Destructor  * * * * * * * * * * * * * * * //
+
+Foam::loadPolicy::~loadPolicy()
+{}
+
+
+// * * * * * * * * * * * * * * * Member Functions  * * * * * * * * * * * * * //
+
+Foam::autoPtr<Foam::loadPolicy> Foam::loadPolicy::New
+(
+    const fvMesh& mesh,
+    const dictionary& dict
+)
+{
+    const word loadPolicyType(dict.lookupOrDefault<word>("loadPolicy", "cellCount"));
+
+    Info<< "Selecting loadPolicy: " << loadPolicyType << endl;
+
+    auto* ctorPtr = dictionaryConstructorTable(loadPolicyType);
+
+    if (ctorPtr == nullptr)
+    {
+        FatalErrorInFunction
+            << "Unknown loadPolicy type "
+            << loadPolicyType << endl << endl
+            << "Valid loadPolicy types are : " << endl
+            << dictionaryConstructorTablePtr_->sortedToc()
+            << exit(FatalError);
+    }
+
+    return ctorPtr(mesh, dict);
+}
+
+// ************************************************************************* //

--- a/src/loadPolicies/loadPolicy/loadPolicy.H
+++ b/src/loadPolicies/loadPolicy/loadPolicy.H
@@ -1,0 +1,174 @@
+/*---------------------------------------------------------------------------*\
+  =========                 |
+  \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+   \\    /   O peration     |
+    \\  /    A nd           | Copyright (C) 2014 Tyler Voskuilen
+     \\/     M anipulation  |
+-------------------------------------------------------------------------------
+21-05-2020 Synthetik Applied Technologies: |   Modified original
+                            dynamicRefineBalanceBlastFvMesh class
+                            to be more appilcable to compressible flows.
+                            Improved compatibility with snappyHexMesh.
+-------------------------------------------------------------------------------
+License
+    This file is a derivative work of OpenFOAM.
+
+    OpenFOAM is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    OpenFOAM is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+    for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with OpenFOAM.  If not, see <http://www.gnu.org/licenses/>.
+
+
+Class
+    Foam::loadPolicy
+
+SourceFiles
+    loadPolicy.C
+
+Description
+    A base class for tracking MPI-processor-local CPU load.
+
+\*---------------------------------------------------------------------------*/
+
+#ifndef loadPolicy_H
+#define loadPolicy_H
+
+#include "fvMesh.H"
+#include "autoPtr.H"
+#include "HashTable.H"
+#include "runTimeSelectionTables.H"
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+namespace Foam
+{
+
+/*---------------------------------------------------------------------------*\
+                     Class loadPolicy Declaration
+\*---------------------------------------------------------------------------*/
+
+
+class loadPolicy
+{
+protected:
+
+    //- Mesh refence
+    const fvMesh& mesh_;
+
+    //- configuration
+    const dictionary& dict_;
+
+    //- allowed imbalance as a fraction of mean of processor loads
+    mutable scalar allowedImbalance_;
+
+    //- Current load value for this processor
+    mutable scalar myLoad_;
+
+    //- Load history for this processor
+    //  indexed with time index
+    mutable HashTable<scalar, label> myLoadHistory_;
+
+public:
+
+    //- Runtime type information
+    TypeName("loadPolicy");
+
+    declareRunTimeSelectionTable
+    (
+        autoPtr,
+        loadPolicy,
+        dictionary,
+        (
+            const fvMesh& mesh,
+            const dictionary& dict
+        ),
+        (mesh, dict)
+    );
+
+    // Constructors
+
+        //- Construct from IOobject
+        loadPolicy
+        (
+            const fvMesh& mesh,
+            const dictionary& dict
+        );
+
+        //- Disallow default bitwise copy construction
+        loadPolicy(const loadPolicy&) = delete;
+
+        static autoPtr<loadPolicy> New
+        (
+            const fvMesh& mesh,
+            const dictionary& dict
+        );
+
+
+    //- Destructor
+    virtual ~loadPolicy();
+
+
+    // Member Functions
+
+        //- Return the dynamicMeshDict
+        const dictionary& dynamicMeshDict() const
+        {
+            return dict_;
+        }
+
+        //- Return allowed imbalance
+        scalar allowedImbalance() const {
+            return allowedImbalance_;
+        }
+
+        //- Return current load value
+        scalar myLoad() const {
+            if (myLoad_ == -1)
+            {
+                FatalErrorInFunction
+                    << "The load-balancer is requesting a load before it is computed... This is not allowed."
+                    << abort(FatalError);
+            }
+            return myLoad_;
+        }
+
+        const HashTable<scalar, label>& myLoadHistory() const{
+            return myLoadHistory_;
+        }
+
+        //- Compute loads and see if should balance
+        virtual bool canBalance() = 0;
+
+        //- Compute and return cell weights for decomposition
+        virtual scalarField cellWeights() = 0;
+
+        //- Predict if LB would be viable
+        virtual bool willBeBeneficial
+        (
+            const labelList distribution
+        ) = 0;
+
+    // Member Operators
+
+        //- Disallow default bitwise assignment
+        void operator=(const loadPolicy&) = delete;
+};
+
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+} // End namespace Foam
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+#endif
+
+// ************************************************************************* //

--- a/tutorials/damBreak2D/Allrun
+++ b/tutorials/damBreak2D/Allrun
@@ -20,7 +20,7 @@ for i in $(seq 1 $maxRef); do
     runApplication -a setFields
 done
 cp -rT 0/polyMesh constant/polyMesh
-runApplication decomposePar -constant
+runApplication decomposePar -constant -cellDist
 #mpirun -np 8 --output-filename log interFoam -parallel
 
 #------------------------------------------------------------------------------

--- a/tutorials/damBreak2D/constant/dynamicMeshDict
+++ b/tutorials/damBreak2D/constant/dynamicMeshDict
@@ -66,9 +66,11 @@ code
 
 balance         yes;
 
-refineInterval  1;
+loadPolicy cpuLoad;
 
-unrefineInterval 1;
+refineInterval  50;
+
+unrefineInterval 250;
 
 maxRefinement   2;
 

--- a/tutorials/damBreak2D/system/controlDict
+++ b/tutorials/damBreak2D/system/controlDict
@@ -19,7 +19,7 @@ libs
 (
     libamrDynamicFvMesh.so
     libamrIndicators.so
-    libamrDynamicMesh.so
+    libamrCPULoad.so
 );
 
 application     interFoam;


### PR DESCRIPTION
- Default load policy: `cellCount`; for now has no changes but waiting on clouds LB
- Additional CPUTime load policy that gets loaded by its own library (Because it overrides MPI calls)

This PR simplifies coming up with new load policies that can be independent on AMR.

Planned as future work:
- `cellCount` can have a coefficient to balance "cell count"  and "particles count" in a processor.