### PR TITLE
Fix uninitialized boolList in hexRef2DAxi::consistentUnrefinement and hexRef1D::consistentUnrefinement

### DIFF
--- a/src/dynamicMesh/fvMeshRefiner/fvMeshHexRefiner/hexRef/hexRef1D__/hexRef1D.C
+++ b/src/dynamicMesh/fvMeshRefiner/fvMeshHexRefiner/hexRef/hexRef1D__/hexRef1D.C
@@ -1571,7 +1571,7 @@ Foam::labelList Foam::hexRef1D::consistentUnrefinement
     // maxSet = true: select edges to refine
 
     // Maintain boolList for edgesToUnrefine and cellsToUnrefine
-    boolList unrefineEdge(mesh_.nEdges());
+    boolList unrefineEdge(mesh_.nEdges(), false);
 
     forAll(edgesToUnrefine, i)
     {
@@ -1587,7 +1587,7 @@ Foam::labelList Foam::hexRef1D::consistentUnrefinement
         // ~~~~~~~~~~~~~~~~~~~~~~~~~~~
         const labelListList& edgeCells = mesh_.edgeCells();
 
-        boolList unrefineCell(mesh_.nCells());
+        boolList unrefineCell(mesh_.nCells(), false);
 
         forAll(unrefineEdge, edgei)
         {

--- a/src/dynamicMesh/fvMeshRefiner/fvMeshHexRefiner/hexRef/hexRef2DAxi/hexRef2DAxi.C
+++ b/src/dynamicMesh/fvMeshRefiner/fvMeshHexRefiner/hexRef/hexRef2DAxi/hexRef2DAxi.C
@@ -2004,7 +2004,7 @@ Foam::labelList Foam::hexRef2DAxi::consistentUnrefinement
     // maxSet = true: select edges to refine
 
     // Maintain boolList for edgesToUnrefine and cellsToUnrefine
-    boolList unrefineEdge(mesh_.nEdges());
+    boolList unrefineEdge(mesh_.nEdges(), false);
 
     forAll(edgesToUnrefine, i)
     {
@@ -2020,7 +2020,7 @@ Foam::labelList Foam::hexRef2DAxi::consistentUnrefinement
         // ~~~~~~~~~~~~~~~~~~~~~~~~~~~
         const labelListList& edgeCells = mesh_.edgeCells();
 
-        boolList unrefineCell(mesh_.nCells());
+        boolList unrefineCell(mesh_.nCells(), false);
 
         forAll(unrefineEdge, edgei)
         {


### PR DESCRIPTION
In hexRef2DAxi::consistentUnrefinement and hexRef1D::consistentUnrefinement, unrefineEdge and unrefineCell are constructed without an initial value, so their entries are indeterminate. The function only .set()s a subset and assumes the rest are false, so leftover-memory true entries select edges/cells that were never unrefinement candidates. 

Symptom: Selected N split edges out of a possible M with N ≫ M, followed by a fatal in setUnrefinement (master … not the lowest numbered cell among the edgeCells). Because it depends on uninitialised memory, it's intermittent. The sibling refiners hexRef2D and hexRef3D already initialise the equivalent lists to false; this change makes hexRef2DAxi and hexRef1D consistent.